### PR TITLE
Add Oh My Posh installer component for Linux shells

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,9 @@
+# Dotfiles Ruby installer
+
+## Shell components
+
+### Oh My Posh (Linux)
+- Component: `Component::OhMyPoshComponent`
+- Installs the latest Linux AMD64 Oh My Posh binary to `$HOME/.local/bin/oh-my-posh` using `curl`.
+- Seeds a starter theme at `$HOME/.poshthemes/default.omp.json` from `ruby/data/oh_my_posh/default.omp.json`.
+- Designed for Ubuntu/Linux shells; Windows installation is not handled here.

--- a/ruby/data/oh_my_posh/default.omp.json
+++ b/ruby/data/oh_my_posh/default.omp.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "final_space": true,
+  "console_title": false,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "os",
+          "style": "diamond",
+          "foreground": "#98C379",
+          "background": "#1F2227"
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "foreground": "#61AFEF",
+          "background": "#1F2227",
+          "properties": {
+            "style": "folder",
+            "folder_separator_icon": ""
+          }
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "foreground": "#E5C07B",
+          "background": "#1F2227",
+          "properties": {
+            "branch_icon": " "
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "shell",
+          "style": "plain",
+          "foreground": "#56B6C2",
+          "properties": {
+            "mapped_shell_names": {
+              "zsh": "zsh",
+              "bash": "bash"
+            }
+          }
+        },
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "#ABB2BF",
+          "properties": {
+            "time_format": "15:04"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/lib/components/shell/oh_my_posh.rb
+++ b/ruby/lib/components/shell/oh_my_posh.rb
@@ -1,0 +1,74 @@
+require 'fileutils'
+require 'components/base'
+require 'components/configuration'
+require 'mixins/installable'
+require 'components/fetch/curl'
+
+module Component
+  class OhMyPoshComponent < BaseComponent
+    prepend Installable
+
+    CONFIG = Components::Configuration.instance
+
+    DOWNLOAD_URL = 'https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64'
+    TMP_BINARY_PATH = File.join(CONFIG.tmp, 'oh-my-posh')
+    BINARY_PATH = File.join(CONFIG.bin, 'oh-my-posh')
+
+    THEMES_DIR = File.join(CONFIG.home, '.poshthemes')
+    DEFAULT_THEME_SOURCE = File.join(DATA_ROOT, 'oh_my_posh', 'default.omp.json')
+    DEFAULT_THEME_PATH = File.join(THEMES_DIR, 'default.omp.json')
+
+    depends_on Component::CurlComponent
+
+    def available?
+      File.exist?(BINARY_PATH) && File.executable?(BINARY_PATH)
+    end
+
+    def installed?
+      available? && File.exist?(DEFAULT_THEME_PATH)
+    end
+
+    def install
+      if installed?
+        logger.info('Oh My Posh already installed.')
+        return
+      end
+
+      install!
+    end
+
+    def install!
+      logger.info('Installing Oh My Posh for Linux shells')
+      FileUtils.mkdir_p(CONFIG.bin) unless Dir.exist?(CONFIG.bin)
+
+      download_binary
+      install_theme
+    rescue => e
+      logger.error("Failed to install Oh My Posh: #{e}")
+      raise e
+    ensure
+      cleanup_tmp_binary
+    end
+
+    private
+
+    def download_binary
+      curl.download(DOWNLOAD_URL, TMP_BINARY_PATH)
+      FileUtils.mv(TMP_BINARY_PATH, BINARY_PATH)
+      FileUtils.chmod(0o755, BINARY_PATH)
+    end
+
+    def install_theme
+      unless File.exist?(DEFAULT_THEME_SOURCE)
+        raise "Default theme not found at #{DEFAULT_THEME_SOURCE}"
+      end
+
+      FileUtils.mkdir_p(THEMES_DIR) unless Dir.exist?(THEMES_DIR)
+      FileUtils.cp(DEFAULT_THEME_SOURCE, DEFAULT_THEME_PATH)
+    end
+
+    def cleanup_tmp_binary
+      FileUtils.rm_f(TMP_BINARY_PATH) if File.exist?(TMP_BINARY_PATH)
+    end
+  end
+end

--- a/ruby/spec/lib/components/shell/oh_my_posh_spec.rb
+++ b/ruby/spec/lib/components/shell/oh_my_posh_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'components/shell/oh_my_posh'
+require 'components/fetch/curl'
+
+RSpec.describe Component::OhMyPoshComponent do
+  subject(:oh_my_posh) { described_class.instance }
+
+  let(:mock_curl) { instance_spy(Component::CurlComponent) }
+  let(:mock_logger) { Logger.new(File::NULL) }
+
+  before do
+    allow(Component::CurlComponent).to receive(:instance).and_return(mock_curl)
+    allow(oh_my_posh).to receive(:curl).and_return(mock_curl)
+    allow(oh_my_posh).to receive(:logger).and_return(mock_logger)
+  end
+
+  describe '#available?' do
+    it 'returns true when binary exists and is executable' do
+      allow(File).to receive(:exist?).with(described_class::BINARY_PATH).and_return(true)
+      allow(File).to receive(:executable?).with(described_class::BINARY_PATH).and_return(true)
+
+      expect(oh_my_posh.available?).to be true
+    end
+
+    it 'returns false when binary is missing' do
+      allow(File).to receive(:exist?).with(described_class::BINARY_PATH).and_return(false)
+
+      expect(oh_my_posh.available?).to be false
+    end
+  end
+
+  describe '#installed?' do
+    it 'returns true when binary and theme exist' do
+      allow(oh_my_posh).to receive(:available?).and_return(true)
+      allow(File).to receive(:exist?).with(described_class::DEFAULT_THEME_PATH).and_return(true)
+
+      expect(oh_my_posh.installed?).to be true
+    end
+
+    it 'returns false when theme is missing' do
+      allow(oh_my_posh).to receive(:available?).and_return(true)
+      allow(File).to receive(:exist?).with(described_class::DEFAULT_THEME_PATH).and_return(false)
+
+      expect(oh_my_posh.installed?).to be false
+    end
+  end
+
+  describe '#install' do
+    context 'when already installed' do
+      it 'skips installation' do
+        allow(oh_my_posh).to receive(:installed?).and_return(true)
+
+        oh_my_posh.install
+
+        expect(mock_curl).not_to have_received(:download)
+      end
+    end
+
+    context 'when not installed' do
+      before do
+        allow(oh_my_posh).to receive(:installed?).and_return(false)
+      end
+
+      it 'downloads binary and installs theme' do
+        allow(mock_curl).to receive(:available?).and_return(true)
+        allow(mock_curl).to receive(:download).with(
+          described_class::DOWNLOAD_URL,
+          described_class::TMP_BINARY_PATH
+        )
+
+        allow(FileUtils).to receive(:mkdir_p).and_return(true)
+        allow(FileUtils).to receive(:mv)
+        allow(FileUtils).to receive(:chmod)
+        allow(FileUtils).to receive(:cp)
+        allow(FileUtils).to receive(:rm_f)
+
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_THEME_SOURCE).and_return(true)
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_THEME_PATH).and_return(false)
+        allow(File).to receive(:exist?).with(described_class::TMP_BINARY_PATH).and_return(true)
+        allow(Dir).to receive(:exist?).with(described_class::THEMES_DIR).and_return(false)
+        allow(Dir).to receive(:exist?).with(described_class::CONFIG.bin).and_return(true)
+
+        oh_my_posh.install
+
+        expect(mock_curl).to have_received(:download).with(
+          described_class::DOWNLOAD_URL,
+          described_class::TMP_BINARY_PATH
+        )
+        expect(FileUtils).to have_received(:mv).with(
+          described_class::TMP_BINARY_PATH,
+          described_class::BINARY_PATH
+        )
+        expect(FileUtils).to have_received(:chmod).with(0o755, described_class::BINARY_PATH)
+        expect(FileUtils).to have_received(:cp).with(
+          described_class::DEFAULT_THEME_SOURCE,
+          described_class::DEFAULT_THEME_PATH
+        )
+        expect(FileUtils).to have_received(:rm_f).with(described_class::TMP_BINARY_PATH)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add an installable Oh My Posh component that downloads the Linux binary and seeds a default theme
- provide a starter Oh My Posh theme asset for local setups
- document Linux-only Oh My Posh support alongside new specs

## Testing
- bundle exec rspec *(fails: rspec gem unavailable due to Bundler fetch errors in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227287e138832b910ca493c74f7173)