### PR TITLE
Allow docker test script to target specific distros

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -2,7 +2,7 @@
 
 install.sh은 Bash 를 이용하여 Ruby를 설치하는 스크립트와 관련 테스트를 포함합니다.
 
-현재는 Ubuntu만 지원합니다.
+현재는 Ubuntu, Rocky Linux, openSUSE를 지원합니다.
 
 ## 설치 방법
 

--- a/shell/docker-test.sh
+++ b/shell/docker-test.sh
@@ -1,5 +1,62 @@
 #!/bin/bash
+set -euo pipefail
 
-docker build --progress plain -t dotfiles:shell -f test/Dockerfile .
-docker image inspect dotfiles:shell >/dev/null && echo "✅ Docker image build: dotfiles:shell" || (echo "❌ Docker image build failed"; exit 1)
+cd "$(dirname "$0")"
 
+usage() {
+  cat <<'USAGE'
+Usage: ./docker-test.sh [--all | <distro> [<distro> ...]]
+
+Options:
+  --all        Build images for all available distributions.
+  <distro>     One or more distro names matching docker-test/<distro>.Dockerfile.
+
+Examples:
+  ./docker-test.sh ubuntu
+  ./docker-test.sh rocky opensuse
+  ./docker-test.sh --all
+USAGE
+}
+
+mapfile -t available_distros < <(for f in docker-test/*.Dockerfile; do basename "$f" .Dockerfile; done)
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+declare -A requested
+
+for arg in "$@"; do
+  if [[ $arg == "--all" ]]; then
+    for distro in "${available_distros[@]}"; do
+      requested[$distro]=1
+    done
+    continue
+  fi
+
+  if [[ -f "docker-test/${arg}.Dockerfile" ]]; then
+    requested[$arg]=1
+  else
+    echo "Unknown distro: ${arg}" >&2
+    usage
+    exit 1
+  fi
+done
+
+if [[ ${#requested[@]} -eq 0 ]]; then
+  echo "No distributions selected." >&2
+  usage
+  exit 1
+fi
+
+mapfile -t selected_distros < <(printf '%s\n' "${!requested[@]}" | sort)
+
+for distro in "${selected_distros[@]}"; do
+  dockerfile="docker-test/${distro}.Dockerfile"
+  tag="dotfiles:shell-${distro}"
+  echo "Building ${tag}..."
+  docker build --progress plain -t "$tag" -f "$dockerfile" .
+  docker image inspect "$tag" >/dev/null && echo "✅ Docker image build: $tag"
+  echo
+done

--- a/shell/docker-test/README.md
+++ b/shell/docker-test/README.md
@@ -1,0 +1,24 @@
+# Shell Docker Test Images
+
+Build Docker images to validate the shell installer across supported distributions. Each Dockerfile runs unit tests and the full installation flow inside a clean container.
+
+## Available images
+- `docker-test/ubuntu.Dockerfile` (Ubuntu 20.04)
+- `docker-test/rocky.Dockerfile` (Rocky Linux 9)
+- `docker-test/opensuse.Dockerfile` (openSUSE Leap 15.6)
+
+## Build images
+From the `shell` directory, pass one or more distro names that match the Dockerfile basenames:
+
+```bash
+./docker-test.sh ubuntu
+./docker-test.sh rocky opensuse
+```
+
+To build every available image in sequence, use `--all`:
+
+```bash
+./docker-test.sh --all
+```
+
+Successful builds indicate the installer and tests completed without errors.

--- a/shell/docker-test/opensuse.Dockerfile
+++ b/shell/docker-test/opensuse.Dockerfile
@@ -1,0 +1,57 @@
+FROM opensuse/leap:15.6
+
+# Install base tooling and bats
+RUN zypper -n refresh \
+    && zypper -n install --no-recommends \
+        sudo \
+        curl \
+        wget \
+        git \
+        vim \
+        zsh \
+        which \
+        gcc \
+        make \
+        openssl-devel \
+        readline-devel \
+        zlib-devel \
+        bzip2 \
+        libbz2-devel \
+        sqlite3 \
+        sqlite3-devel \
+        xz \
+        xz-devel \
+        bats \
+    && zypper clean --all
+
+# Ensure wheel group exists and create a test user with sudo privileges
+RUN groupadd -r wheel || true
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser:testuser" | chpasswd && \
+    usermod -aG wheel testuser && \
+    echo "%wheel ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/wheel && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/testuser && \
+    chmod 440 /etc/sudoers.d/wheel /etc/sudoers.d/testuser
+
+# Switch to test user
+USER testuser
+WORKDIR /home/testuser
+
+# Copy shell directory contents including all tests
+COPY --chown=testuser:testuser ./install.sh ./shell/install.sh
+COPY --chown=testuser:testuser ./internal ./shell/internal
+COPY --chown=testuser:testuser ./lib ./shell/lib
+COPY --chown=testuser:testuser ./README.md ./shell/README.md
+COPY --chown=testuser:testuser ./test ./shell/test
+
+# Make scripts executable
+RUN chmod +x ./shell/install.sh ./shell/test/test_install.sh ./shell/test/test_units.sh
+
+# Run unit tests BEFORE installation
+RUN ./shell/test/test_units.sh
+
+# Run installation and integration tests (needs sudo)
+RUN ./shell/test/test_install.sh
+
+# Default command
+CMD ["/bin/bash", "-l"]

--- a/shell/docker-test/rocky.Dockerfile
+++ b/shell/docker-test/rocky.Dockerfile
@@ -1,0 +1,57 @@
+FROM rockylinux:9
+
+# Install base tooling and bats from EPEL
+RUN dnf -y install epel-release \
+    && dnf -y install \
+        sudo \
+        curl \
+        wget \
+        git \
+        vim \
+        zsh \
+        which \
+        gcc \
+        make \
+        openssl-devel \
+        readline-devel \
+        zlib-devel \
+        bzip2 \
+        bzip2-devel \
+        sqlite \
+        sqlite-devel \
+        xz \
+        xz-devel \
+        bats \
+    && dnf clean all
+
+# Ensure wheel group exists and create a test user with sudo privileges
+RUN groupadd -r wheel || true
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser:testuser" | chpasswd && \
+    usermod -aG wheel testuser && \
+    echo "%wheel ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/wheel && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/testuser && \
+    chmod 440 /etc/sudoers.d/wheel /etc/sudoers.d/testuser
+
+# Switch to test user
+USER testuser
+WORKDIR /home/testuser
+
+# Copy shell directory contents including all tests
+COPY --chown=testuser:testuser ./install.sh ./shell/install.sh
+COPY --chown=testuser:testuser ./internal ./shell/internal
+COPY --chown=testuser:testuser ./lib ./shell/lib
+COPY --chown=testuser:testuser ./README.md ./shell/README.md
+COPY --chown=testuser:testuser ./test ./shell/test
+
+# Make scripts executable
+RUN chmod +x ./shell/install.sh ./shell/test/test_install.sh ./shell/test/test_units.sh
+
+# Run unit tests BEFORE installation
+RUN ./shell/test/test_units.sh
+
+# Run installation and integration tests (needs sudo)
+RUN ./shell/test/test_install.sh
+
+# Default command
+CMD ["/bin/bash", "-l"]

--- a/shell/docker-test/ubuntu.Dockerfile
+++ b/shell/docker-test/ubuntu.Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:20.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install basic tools
+RUN apt-get update && apt-get install -y \
+    sudo \
+    curl \
+    wget \
+    git \
+    vim \
+    zsh \
+    build-essential \
+    software-properties-common \
+    locales \
+    bats \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a test user with sudo privileges
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser:testuser" | chpasswd && \
+    usermod -aG sudo testuser && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/testuser && \
+    chmod 440 /etc/sudoers.d/testuser
+
+# Switch to test user
+USER testuser
+WORKDIR /home/testuser
+
+# Copy shell directory contents including all tests
+COPY --chown=testuser:testuser ./install.sh ./shell/install.sh
+COPY --chown=testuser:testuser ./internal ./shell/internal
+COPY --chown=testuser:testuser ./lib ./shell/lib
+COPY --chown=testuser:testuser ./README.md ./shell/README.md
+COPY --chown=testuser:testuser ./test ./shell/test
+
+# Make scripts executable
+RUN chmod +x ./shell/install.sh ./shell/test/test_install.sh ./shell/test/test_units.sh
+
+# Run unit tests BEFORE installation
+RUN ./shell/test/test_units.sh
+
+# Run installation and integration tests (needs sudo)
+RUN ./shell/test/test_install.sh
+
+# Default command
+CMD ["/bin/bash", "-l"]

--- a/shell/test/README.md
+++ b/shell/test/README.md
@@ -1,6 +1,7 @@
 # Shell Installation Test with Docker
 
 This directory contains Docker-based testing for the shell installation script.
+For multi-distribution images (Ubuntu, Rocky Linux, openSUSE), see `../docker-test`.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- add argument parsing to docker-test.sh to build selected distributions or all via --all
- document the new usage patterns for building one or multiple test images

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b929c6820832bb14eac82379719b0)