### PR TITLE
feat(19): Add plugins after install oh-my-zsh

### DIFF
--- a/ruby/lib/components/shell/oh_my_zsh.rb
+++ b/ruby/lib/components/shell/oh_my_zsh.rb
@@ -74,7 +74,7 @@ module Component
       end
       plugins_string += ")"
 
-      if zshrc_content.gsub!(/^[^#]*plugins=\([^)]*\)/, "#{plugins_string}")
+      if zshrc_content.gsub!(/^[^#]*plugins=\([^)]*\)/m, "#{plugins_string}")
         logger.info("Updated plugins in .zshrc")
       else
         logger.warn("plugins=() not found in .zshrc")

--- a/ruby/spec/lib/components/shell/oh_my_zsh_spec.rb
+++ b/ruby/spec/lib/components/shell/oh_my_zsh_spec.rb
@@ -109,8 +109,10 @@ RSpec.describe Component::OhMyZshComponent do
       it 'replaces the existing plugins array' do
         # Given
         original_content = <<~CONTENT
+          # Welcome to oh-my-zsh!
           export ZSH="$HOME/.oh-my-zsh"
           ZSH_THEME="robbyrussell"
+          # plugins=(git)
           plugins=(git)
           source $ZSH/oh-my-zsh.sh
         CONTENT
@@ -129,6 +131,7 @@ RSpec.describe Component::OhMyZshComponent do
         # Then
         expect(file_handle).to have_received(:write) do |content|
           expect(content).to match(/plugins=\([^)\n]+\)/)
+          expect(content).to include(/\# plugins=\(git\)/)
         end
       end
     end


### PR DESCRIPTION
Oh-my-zsh plugins을 oh-my-zsh 설치 후에 바로 설정합니다.

oh-my-zsh 이 설치되면, 일반적으로 .zshrc 가 설정되므로 거기에 plugins 을 찾아 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oh My Zsh component now configures plugins automatically after installation (git, ruby, python, systemd, docker, pip, command-not-found, docker-compose).
  * Appends or updates the plugins line in the user's zsh config.

* **Bug Fixes**
  * Errors clearly when the zsh configuration file is missing.

* **Tests**
  * Added tests covering successful update, appending behavior, and missing-file error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->